### PR TITLE
Fix 2 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "chai": "^3.5.0",
     "chai-http": "^3.0.0",
     "sinon": "^1.17.5",
-    "mocha": "^3.0.0",
+    "mocha": "10.1.0",
     "mocha-junit-reporter": "^1.12.1",
     "istanbul": "^0.4.4",
-    "mongodb": "^2.2.5"
+    "mongodb": "3.1.13"
   }
 }


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Tue, 19 Dec 2023 11:58:07 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
high | package.json | mongodb | [GHSA-mh5c-679w-hh4r](https://github.com/advisories/GHSA-mh5c-679w-hh4r) | 7.0 | fixed in 3.1.13 | Versions of `mongodb` prior to 3.1.13 are vulnerable to Denial of Service. The package fails to properly catch an exception when a collection name is invalid and the DB does not exist, crashing the application.   ## Recommendation  Upgrade to version 3.1.13 or later.
high | package.json | mocha | [PRISMA-2022-0230](https://github.com/mochajs/mocha/pull/4770) | 7.5 | fixed in 10.1.0 | mocha packages versions before 10.1.0 are vulnerable to Regular Expression Denial of Service (ReDoS). clean() function is vulnerable to ReDoS attacks due to the overlapped sub-patterns.
